### PR TITLE
Add order invoice property to submitTransaction and authorizeTransaction

### DIFF
--- a/lib/AuthorizeNetGateway.js
+++ b/lib/AuthorizeNetGateway.js
@@ -139,6 +139,12 @@ AuthorizeNetGateway.prototype.submitTransaction = function submitTransaction (or
     }
   };
 
+  if(order.invoiceNumber !== undefined) {
+    body.order = {
+      invoiceNumber: order.invoiceNumber
+    }
+  }
+
   if (prospect) {
     body.billTo = mapKeys(prospect, billToSchema);
     body.shipTo = mapKeys(prospect, shipToSchema);
@@ -175,6 +181,12 @@ AuthorizeNetGateway.prototype.authorizeTransaction = function authorizeTransacti
       }
     }
   };
+
+  if(order.invoiceNumber !== undefined) {
+    body.order = {
+      invoiceNumber: order.invoiceNumber
+    }
+  }
 
   if (prospect) {
     body.billTo = mapKeys(prospect, billToSchema);


### PR DESCRIPTION
This doesn't break backwards compatibility with anything diue to adding in the property via extending the Order Model.

 Example:

```javascript
    var Order = require('42-cent-model').Order;
    var OrderProperties = {
        invoiceNumber: 'AAAAAA-1234555'
    };

    var Order = new Order(OrderProperties);
```