### PR TITLE
ErrorResponse throws an error.

### DIFF
--- a/lib/AuthorizeNetGateway.js
+++ b/lib/AuthorizeNetGateway.js
@@ -80,7 +80,7 @@ function createJsonCallback (cb) {
         var json = result;
 
         if (json.ErrorResponse) {
-          throw new GatewayError(json.ErrorResponse[0].messages[0].message[0].text[0], json.ErrorResponse[0]);
+          throw new GatewayError(json.ErrorResponse.messages[0].message[0].text[0], json.ErrorResponse[0]);
         }
 
         return cb(json);


### PR DESCRIPTION
json.ErrorResponse contains an object and not array.