### PR TITLE
Add billTo to customer profile.

### DIFF
--- a/lib/AuthorizeNetGateway.js
+++ b/lib/AuthorizeNetGateway.js
@@ -418,6 +418,7 @@ AuthorizeNetGateway.prototype.createCustomerProfile = function (payment, billing
         description: options.description || '',
         email: billing.billingEmailAddress,
         paymentProfiles: {
+          billTo: billing && mapKeys(billing, billToSchema) || undefined,
           payment: {
             creditCard: {
               cardNumber: payment.creditCardNumber,


### PR DESCRIPTION
Adds the obviously intended `billTo` field in `createCustomerProfile`, allowing transactions submitted using `chargeCustomer` to be identified later in the Merchant interface.