### PR TITLE
Using proper byte-length for content payload length

### DIFF
--- a/lib/AuthorizeNetGateway.js
+++ b/lib/AuthorizeNetGateway.js
@@ -64,7 +64,7 @@ function sendXmlifiedRequest (service) {
         return post(service.endpoint, {
           headers: {
             'Content-Type': 'application/xml',
-            'Content-Length': xmlContent.length
+            'Content-Length': Buffer.byteLength(xmlContent)
           },
           body: xmlContent
         })


### PR DESCRIPTION
Depending on the content, string.length and Buffer.byteLength(string) aren't equal, and part of the XML being sent can get cut off causing failed requests to the API.

This simple change fixes the issue.