### PR TITLE
(fix) Update request version to patch vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "42-cent-base": "^0.8.0",
     "42-cent-util": "^1.0.0",
     "bluebird": "^2.3.11",
-    "request": "2.73.0",
+    "request": "2.83.0",
     "xml2js": "^0.4.6"
   },
   "devDependencies": {


### PR DESCRIPTION
This bumps `request` to the current version to fix an upstream security vulnerability in `tough-cookie`. More info about this vulnerability [here](https://snyk.io/vuln/npm:tough-cookie:20160722)